### PR TITLE
Adding formatting for node relationships

### DIFF
--- a/syntaxes/tpl.tmLanguage.json
+++ b/syntaxes/tpl.tmLanguage.json
@@ -1271,6 +1271,25 @@
             }
           ]
         },
+        "node_relationships": {
+          "comment": "Covers node relationships, does not check for proper relationship names",
+          "match": "(?i)([a-z]*):([a-z]*):([a-z]*):([a-z]*)",
+          "name": "keyword.control.conditional.tpl",
+          "captures": {
+            "1": {
+              "name": "variable.parameter.tpl"
+            },
+            "2": {
+              "name": "variable.parameter.tpl"
+            },
+            "3": {
+              "name": "variable.parameter.tpl"
+            },
+            "4": {
+              "name": "variable.parameter.tpl"
+            }
+          }
+        },
         "if_statement": {
           "comment": "Match if ..values.. then and include usual lines. #lines can override some marks",
           "begin": "(?!end if;|then)(\\bif)",
@@ -1464,6 +1483,9 @@
             },
             {
               "include": "#all_keys"
+            },
+            {
+              "include": "#node_relationships"
             }
           ]
         },


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Added block for Node Relationships.
Generic color for delimiters, variable color for relationship names.
Does not check for correct names (error checking should not be covered by formatting).

## Related Issue
<!--- Issues are not REQUIRED for a pull request, but are HIGHLY suggested -->
<!--- Please link to the issue here: -->
#4 

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
Useful to see highlighted relationships.

## Has This Been Tested?
<!--- Describe how you tested your changes -->
Tested with the following:

    test:test:test:test
    test::test:test
    test:::test
    test:test::
    :::test