### PR TITLE
Updated if/else patterns to include keywords and functions (re-doing …

### DIFF
--- a/syntaxes/tpl.tmLanguage.json
+++ b/syntaxes/tpl.tmLanguage.json
@@ -1527,6 +1527,12 @@
             },
             {
               "include": "#lines"
+            },
+            {
+              "include": "#keywords_attrs"
+            },
+            {
+              "include": "#all_functions"
             }
           ]
         },
@@ -1556,6 +1562,12 @@
             },
             {
               "include": "#lines"
+            },
+            {
+              "include": "#keywords_attrs"
+            },
+            {
+              "include": "#all_functions"
             }
           ]
         },


### PR DESCRIPTION
…it for proper branch commit)

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail, use a list if desired -->
Adding proper syntax highlighting for keywords and functions inside if/else blocks.

## Related Issue
<!--- Issues are not REQUIRED for a pull request, but are HIGHLY suggested -->
<!--- Please link to the issue here: -->
#12 

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
Highlighting is especially important inside if/else blocks and should be there.

## Has This Been Tested?
<!--- Describe how you tested your changes -->
    if node_var.type matches regex.extract("(?i)this") then

    else if node_var.type matches regex.extract("(?i)this") then