### PR TITLE
Adding Basic Syncmapping Support

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
     "name": "tpl",
     "displayName": "The Pattern Language (TPL)",
     "description": "The Pattern Language, TPL, files syntax highlighting extension for Visual Studio Code. TPL is used to describe applications, products and other real-world entities that have been modeled in BMC Discovery.",
-    "version": "1.0.0",
+    "version": "1.0.1",
     "publisher": "cdpautsch",
     "author": "cdpautsch",
     "keywords": [
@@ -26,16 +26,25 @@
         "Programming Languages"
     ],
     "contributes": {
-        "languages": [{
-            "id": "tpl",
-            "aliases": ["TPL", "tpl"],
-            "extensions": [".tpl"],
-            "configuration": "./language-configuration.json"
-        }],
-        "grammars": [{
-            "language": "tpl",
-            "scopeName": "source.tpl",
-            "path": "./syntaxes/tpl.tmLanguage.json"
-        }]
+        "languages": [
+            {
+                "id": "tpl",
+                "aliases": [
+                    "TPL",
+                    "tpl"
+                ],
+                "extensions": [
+                    ".tpl"
+                ],
+                "configuration": "./language-configuration.json"
+            }
+        ],
+        "grammars": [
+            {
+                "language": "tpl",
+                "scopeName": "source.tpl",
+                "path": "./syntaxes/tpl.tmLanguage.json"
+            }
+        ]
     }
 }

--- a/syntaxes/tpl.tmLanguage.json
+++ b/syntaxes/tpl.tmLanguage.json
@@ -205,6 +205,9 @@
               "include": "#constants"
             },
             {
+              "include": "#mapping"
+            },
+            {
               "include": "#triggers"
             },
             {
@@ -1520,6 +1523,12 @@
             },
             {
               "include": "#model_rel_functions"
+            },
+            {
+              "include": "#sync_rel_functions"
+            },
+            {
+              "include": "#sync_shared_functions"
             },
             {
               "include": "#log_functions"

--- a/syntaxes/tpl.tmLanguage.json
+++ b/syntaxes/tpl.tmLanguage.json
@@ -339,6 +339,31 @@
             }
           ]
         },
+        "mapping": {
+          "begin": "\\b(mapping)\\s+?$",
+          "beginCaptures": {
+            "1": {
+              "name": "keyword.control.tpl"
+            }
+          },
+          "end": "\\b(end\\mapping;)\\s+?$",
+          "endCaptures": {
+            "1": {
+              "name": "keyword.control.tpl"
+            }
+          },
+          "patterns": [
+            {
+              "include": "#lines"
+            },
+            {
+              "include": "#all_functions"
+            },
+            {
+              "include": "#if_addm"
+            }
+          ]
+        },
         "triggers": {
           "begin": "^\\s*(triggers)\\s+?$",
           "beginCaptures": {
@@ -1081,6 +1106,88 @@
               "name": "entity.name.type.tpl"
             }
           }
+        },
+        "sync_rel_functions": {
+          "comment": "confirm all possible namespace functions and arguments",
+          "begin": "(sync)(\\.)(rel)(\\.)(BMC_Component)",
+          "beginCaptures": {
+            "1": {
+              "name": "entity.name.function.tpl"
+            },
+            "2": {
+              "name": "punctuation.accessor.tpl"
+            },
+            "3": {
+              "name": "support.function.tpl"
+            },
+            "4": {
+              "name": "punctuation.accessor.tpl"
+            },
+            "5": {
+              "name": "constant.character.escape.tpl"
+            }
+          },
+          "end": "\\;",
+          "endCaptures": {
+            "1": {
+              "name": "disabled.tpl"
+            }
+          },
+          "patterns": [
+            {
+              "include": "#lines"
+            },
+            {
+              "include": "#all_controls"
+            },
+            {
+              "include": "#regex"
+            },
+            {
+              "include": "#model_attribute_assignment"
+            }
+          ]
+        },
+        "sync_shared_functions": {
+          "comment": "confirm all possible namespace functions and arguments",
+          "begin": "(sync)(\\.)(shared)(\\.)(BMC_BusinessService)",
+          "beginCaptures": {
+            "1": {
+              "name": "entity.name.function.tpl"
+            },
+            "2": {
+              "name": "punctuation.accessor.tpl"
+            },
+            "3": {
+              "name": "support.function.tpl"
+            },
+            "4": {
+              "name": "punctuation.accessor.tpl"
+            },
+            "5": {
+              "name": "constant.character.escape.tpl"
+            }
+          },
+          "end": "\\;",
+          "endCaptures": {
+            "1": {
+              "name": "disabled.tpl"
+            }
+          },
+          "patterns": [
+            {
+              "include": "#lines"
+            },
+            {
+              "include": "#all_controls"
+            },
+            {
+              "include": "#regex"
+            },
+            {
+              "include": "#model_attribute_assignment"
+            }
+          ]
         },
         "log_functions": {
           "match": "(log)(\\.)(debug|info|warn|error|critical)",

--- a/syntaxes/tpl.tmLanguage.json
+++ b/syntaxes/tpl.tmLanguage.json
@@ -167,7 +167,7 @@
           ]
         },
         {
-          "begin": "^\\b(pattern)\\s+(\\w+)\\s(\\d+(?:\\.\\d+)+)\\s+$",
+          "begin": "^\\b(pattern|syncmapping)\\s+(\\w+)\\s(\\d+(?:\\.\\d+)+)\\s+$",
           "beginCaptures": {
             "1": {
               "name": "keyword.control.tpl"
@@ -179,7 +179,7 @@
               "name": "constant.numeric.tpl"
             }
           },
-          "end": "\\b(end\\spattern;)",
+          "end": "\\b(end\\spattern|syncmapping;)",
           "endCaptures": {
             "1": {
               "name": "keyword.control.tpl"


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail, use a list if desired -->
Syncmapping blocks were not supported in the current syntax highlighting structure.

Updated block which matches `pattern` to also match `syncmapping`, ensuring everything available in `pattern` is also available in `syncmapping`.

**Discussion**:
- Should `syncmapping` get split out into it's own block?
- Need to add proper highlighting for additional syncmapping syntax

## Related Issue
<!--- Issues are not REQUIRED for a pull request, but are HIGHLY suggested -->
<!--- Please link to the issue here: -->
#19 

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
Syncmapping should have proper highlighting. It is a widely used syntax.

## Has This Been Tested?
<!--- Describe how you tested your changes -->
Tested with the following code:

```
tpl 1.5 module CMDB.Extension.Host.Windows;

metadata
		origin := 'COM';
		tree_path := 'COM','CMDB', 'Service', 'Host','Windows';
end metadata;

from CMDB.Host_ComputerSystem import Host_ComputerSystem 2.0;

syncmapping COM_Service_Host_Windows 1.0
    """
    Relate Server with its Hosting Service
    """
    overview
        tags COM, CMDB, Extension, Service;
    end overview;
	
	constants
		SB_Name  := "@SERVICE_NAME@";
	end constants;

    mapping from Host_ComputerSystem.host where os_type = "Windows" as host
	
			SB_service -> BMC_BusinessService;
			
    end mapping;

    body
		
		computersystem := Host_ComputerSystem.computersystem;
		key := text.hash(SB_Name);
		SB_service := sync.shared.BMC_BusinessService(
			key              := key,
			Name             := SB_Name,
			ServiceType		 := 20
		);
            log.debug("COM: Relate %SB_Name% with %computersystem.name%");
            // Relate the BMC_ComputerSystem to the new BMC_BusinessService
            sync.rel.BMC_Component(
                Source      := computersystem,
                Destination := SB_service,
                Name        := "COMPONENT"
            );
            

    end body;

end syncmapping;
```

Screenshot:
![image](https://user-images.githubusercontent.com/28664455/77825731-a4058880-70e1-11ea-86c7-d4b439a3fb35.png)
